### PR TITLE
Prottype 0.0.2

### DIFF
--- a/space_shooting/cdflame.cpp
+++ b/space_shooting/cdflame.cpp
@@ -11,6 +11,7 @@ void syokika(){
 	HERO.LIFE = 3;
 	HERO.movement = 5;
 	HERO.type = red;
+	HERO.soeji = 0;
 	for (int i = 0; i < bullet_count; i++){
 		HERO.BULLET[i].living = FALSE;
 	}
@@ -57,29 +58,14 @@ void Init_BOSS(int i,int x,int y){
 }
 void SET_PLAYER_BULLET(){
 
-	int key = GetJoypadInputState(DX_INPUT_KEY_PAD1);
 	int Tseigyo;
-
-	if (key & PAD_INPUT_A){
 		
-		for (int i = 0; i < 20; i++){
-			if (HERO.BULLET[i].living == FALSE){
-				if (i != 0){
-					HERO.BULLET[i].time = GetNowCount();
-					Tseigyo = HERO.BULLET[i].time - timer - HERO.BULLET[i - 1].time;
-					if (Tseigyo >= 2000){
-						HERO.BULLET[i].time = Tseigyo;
-						HERO.BULLET[i].living = TRUE;
-						HERO.BULLET[i].SBP = HERO.y;
-						HERO.BULLET[i].x = HERO.x;
-						HERO.BULLET[i].y = HERO.y - 50;
-						HERO.BULLET[i].type = HERO.type;
-						HERO.BULLET[i].movement = 7;
-						InitBulletImage(i);
-						break;
-					}
-				}else{
-					HERO.BULLET[i].time = GetNowCount() - timer;
+	for (int i = 0; i < 20; i++, HERO.soeji = i){
+		if (HERO.BULLET[i].living == FALSE){
+			if (i != 0){
+				HERO.BULLET[i].time = GetNowCount();
+				Tseigyo = HERO.BULLET[i].time - HERO.BULLET[HERO.soeji - 1].time;
+				if (Tseigyo >= 250){
 					HERO.BULLET[i].living = TRUE;
 					HERO.BULLET[i].SBP = HERO.y;
 					HERO.BULLET[i].x = HERO.x;
@@ -87,13 +73,42 @@ void SET_PLAYER_BULLET(){
 					HERO.BULLET[i].type = HERO.type;
 					HERO.BULLET[i].movement = 7;
 					InitBulletImage(i);
-					break;
 				}
 
 			}else{
-				
+				if (HERO.soeji != 0){
+					HERO.BULLET[i].time = GetNowCount();
+					Tseigyo = HERO.BULLET[i].time - HERO.BULLET[HERO.soeji].time;
+					if (Tseigyo >= 250){
+						HERO.BULLET[i].time = GetNowCount();
+						HERO.BULLET[i].living = TRUE;
+						HERO.BULLET[i].SBP = HERO.y;
+						HERO.BULLET[i].x = HERO.x;
+						HERO.BULLET[i].y = HERO.y - 50;
+						HERO.BULLET[i].type = HERO.type;
+						HERO.BULLET[i].movement = 7;
+						InitBulletImage(i);
+					}
+				}else{
+					HERO.BULLET[i].time = GetNowCount();
+					HERO.BULLET[i].living = TRUE;
+					HERO.BULLET[i].SBP = HERO.y;
+					HERO.BULLET[i].x = HERO.x;
+					HERO.BULLET[i].y = HERO.y - 50;
+					HERO.BULLET[i].type = HERO.type;
+					HERO.BULLET[i].movement = 7;
+					InitBulletImage(i);
+				}
 			}
+			break;
 		}
-		
 	}
+		
 }
+
+/*
+
+HERO.BULLET[i].time - HERO.BULLET[HERO.soeji].time	33289	int
+
+
+*/

--- a/space_shooting/cdflame.cpp
+++ b/space_shooting/cdflame.cpp
@@ -2,7 +2,7 @@
 
 int bullet_count = sizeof(HERO.BULLET) / sizeof(HERO.BULLET[0]);
 
-
+int KEY_KAISU = 0;
 
 void syokika(){
 	HERO.SC_Hosei = 0;
@@ -58,27 +58,30 @@ void Init_BOSS(int i,int x,int y){
 void SET_PLAYER_BULLET(){
 
 	int key = GetJoypadInputState(DX_INPUT_KEY_PAD1);
+	int Tseigyo;
 
 	if (key & PAD_INPUT_A){
+		
 		for (int i = 0; i < 20; i++){
 			if (HERO.BULLET[i].living == FALSE){
 				if (i != 0){
-					int Tseigyo = timer - HERO.BULLET[i - 1].time;
-					if (Tseigyo <= 1.5){
-						HERO.BULLET[i - 1].time = GetNowCount();
+					HERO.BULLET[i].time = GetNowCount();
+					Tseigyo = HERO.BULLET[i].time - timer - HERO.BULLET[i - 1].time;
+					if (Tseigyo >= 2000){
+						HERO.BULLET[i].time = Tseigyo;
+						HERO.BULLET[i].living = TRUE;
+						HERO.BULLET[i].SBP = HERO.y;
+						HERO.BULLET[i].x = HERO.x;
+						HERO.BULLET[i].y = HERO.y - 50;
+						HERO.BULLET[i].type = HERO.type;
+						HERO.BULLET[i].movement = 7;
+						InitBulletImage(i);
 						break;
 					}
-					HERO.BULLET[i].time = (GetNowCount() / 1000 - timer);
-					HERO.BULLET[i].living = TRUE;
-					HERO.BULLET[i].x = HERO.x;
-					HERO.BULLET[i].y = HERO.y - 50;
-					HERO.BULLET[i].type = HERO.type;
-					HERO.BULLET[i].movement = 7;
-					InitBulletImage(i);
-					break;
 				}else{
-					HERO.BULLET[i].time = (GetNowCount() / 1000 - timer);
+					HERO.BULLET[i].time = GetNowCount() - timer;
 					HERO.BULLET[i].living = TRUE;
+					HERO.BULLET[i].SBP = HERO.y;
 					HERO.BULLET[i].x = HERO.x;
 					HERO.BULLET[i].y = HERO.y - 50;
 					HERO.BULLET[i].type = HERO.type;
@@ -91,6 +94,6 @@ void SET_PLAYER_BULLET(){
 				
 			}
 		}
-
+		
 	}
 }

--- a/space_shooting/cdflame.h
+++ b/space_shooting/cdflame.h
@@ -31,6 +31,7 @@ struct Charadata{
 	int type;/*属性の切り替え*/
 	BOOL living;/*存在証明*/
 	Data BULLET[20];/*自機/敵機の弾*/
+	int soeji;/*弾が何発撃たれたのかを記録*/
 	int StageNum;/*コンティニューする際のステージナンバーの記録*/
 	int IMGH[4][12];/*自機の画像*/
 };

--- a/space_shooting/cdflame.h
+++ b/space_shooting/cdflame.h
@@ -10,6 +10,7 @@ enum ATKtype{
 };
 
 struct Data{
+	float SBP;/*’e‚ªÅ‰‚Éo‚½êŠ*/
 	float x; /*‰¡²*/
 	float y; /*c²*/
 	BOOL living; /*‘¶İØ–¾*/
@@ -53,6 +54,7 @@ extern CharaData STAGEBOSS;
 
 extern int hx,ex;
 extern int hy,ey;
+extern int KEY_KAISU;
 
 void syokika();
 void Init_ENEMY1(int, int, int);

--- a/space_shooting/cdprocess.cpp
+++ b/space_shooting/cdprocess.cpp
@@ -54,11 +54,9 @@ void CheckScroll(int flag){
 	int field_head = 0;
 	
 	if (HERO.y >= 0 && HERO.y <= 800){
-		if (flag == 2){
-			scrolly -= HERO.movement;
-			HERO.SC_Hosei += HERO.movement;
+		if (HERO.y + IMGSIZE + HERO.movement - HERO.SC_Hosei > 800){
+			HERO.y -= HERO.movement;
 		}
-
 	}
 	if (HERO.y > 800 && HERO.y <= 1950){
 		if (flag == 1){
@@ -98,16 +96,16 @@ void DrawBullet(int flag){
 				switch (HERO.BULLET[i].type)
 				{
 				case red:
-					DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].BULLET_IMAGE, TRUE);
+					DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950 + scrolly, HERO.BULLET[i].BULLET_IMAGE, TRUE);
 					break;
 				case blue:
-					DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].BULLET_IMAGE, TRUE);
+					DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950 + scrolly, HERO.BULLET[i].BULLET_IMAGE, TRUE);
 					break;
 				case green:
-					DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].BULLET_IMAGE, TRUE);
+					DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950 + scrolly, HERO.BULLET[i].BULLET_IMAGE, TRUE);
 					break;
 				case beam:
-					DrawExtendGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].x + IMGSIZE, HERO.BULLET[i].y - 1950 + IMGSIZE, HERO.BULLET[i].BULLET_IMAGE, TRUE);
+					DrawExtendGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950 + scrolly, HERO.BULLET[i].x + IMGSIZE, HERO.BULLET[i].y - 1950 + scrolly + IMGSIZE, HERO.BULLET[i].BULLET_IMAGE, TRUE);
 					break;
 				}
 				if (HERO.BULLET[i].living == TRUE && HERO.BULLET[i].SBP - 800 > HERO.BULLET[i].y){

--- a/space_shooting/cdprocess.cpp
+++ b/space_shooting/cdprocess.cpp
@@ -91,28 +91,37 @@ void DrawBullet(int flag){
 
 	if (flag == E){
 
-	}else if (flag == P){
-		for (int i = 0; HERO.BULLET[i].living == TRUE; i++){
-			switch (HERO.BULLET[i].type)
-			{
-			case red:
-				DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].BULLET_IMAGE, TRUE);
-				break;
-			case blue:
-				DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].BULLET_IMAGE, TRUE);
-				break;
-			case green:
-				DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].BULLET_IMAGE, TRUE);
-				break;
-			case beam:
-				DrawExtendGraph(HERO.BULLET[i].x,HERO.BULLET[i].y - 1950,HERO.BULLET[i].x + IMGSIZE,HERO.BULLET[i].y - 1950 + IMGSIZE,HERO.BULLET[i].BULLET_IMAGE,TRUE);
-				break;
-			}
-			if (HERO.BULLET[i].living == TRUE && HERO.BULLET[i].SBP - 800 > HERO.BULLET[i].y){
-				HERO.BULLET[i].living = FALSE;
-			}
-			if(HERO.BULLET[i].living == TRUE){
-				HERO.BULLET[i].y -= HERO.BULLET[i].movement;
+	}
+	else if (flag == P){
+		for (int i = 0; i < 20; i++){
+			if (HERO.BULLET[i].living == TRUE){
+				switch (HERO.BULLET[i].type)
+				{
+				case red:
+					DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].BULLET_IMAGE, TRUE);
+					break;
+				case blue:
+					DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].BULLET_IMAGE, TRUE);
+					break;
+				case green:
+					DrawGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].BULLET_IMAGE, TRUE);
+					break;
+				case beam:
+					DrawExtendGraph(HERO.BULLET[i].x, HERO.BULLET[i].y - 1950, HERO.BULLET[i].x + IMGSIZE, HERO.BULLET[i].y - 1950 + IMGSIZE, HERO.BULLET[i].BULLET_IMAGE, TRUE);
+					break;
+				}
+				if (HERO.BULLET[i].living == TRUE && HERO.BULLET[i].SBP - 800 > HERO.BULLET[i].y){
+					HERO.BULLET[i].BULLET_IMAGE = NULL;
+					HERO.BULLET[i].living = FALSE;
+					HERO.BULLET[i].movement = 0;
+					HERO.BULLET[i].SBP = 0;
+					HERO.BULLET[i].time = 0;
+					HERO.BULLET[i].x = 0;
+					HERO.BULLET[i].y = 0;
+				}
+				if (HERO.BULLET[i].living == TRUE){
+					HERO.BULLET[i].y -= HERO.BULLET[i].movement;
+				}
 			}
 		}
 	}

--- a/space_shooting/cdprocess.cpp
+++ b/space_shooting/cdprocess.cpp
@@ -116,7 +116,7 @@ void DrawBullet(int flag){
 				DrawExtendGraph(HERO.BULLET[i].x,HERO.BULLET[i].y - 1950,HERO.BULLET[i].x + IMGSIZE,HERO.BULLET[i].y - 1950 + IMGSIZE,HERO.BULLET[i].BULLET_IMAGE,TRUE);
 				break;
 			}
-			if (HERO.BULLET[i].y + IMGSIZE <= (HERO.y + 110 - gamemainsize_y)){
+			if (){
 				HERO.BULLET[i].living = FALSE;
 			}
 			if(HERO.BULLET[i].living == TRUE){

--- a/space_shooting/cdprocess.cpp
+++ b/space_shooting/cdprocess.cpp
@@ -7,14 +7,6 @@ float scrolly = 0;
 void move(){
 	int key = GetJoypadInputState(DX_INPUT_KEY_PAD1);
 
-	int aa = timer;
-	float hy = HERO.y - 1700;
-	aa += 1;
-	if (timer < aa)
-	{
-		//scrolly += 1;
-	}
-
 	if (key & PAD_INPUT_UP && CheckEnd(1) == TRUE){
 		HERO.y -= HERO.movement;
 		CheckScroll(1);
@@ -116,7 +108,7 @@ void DrawBullet(int flag){
 				DrawExtendGraph(HERO.BULLET[i].x,HERO.BULLET[i].y - 1950,HERO.BULLET[i].x + IMGSIZE,HERO.BULLET[i].y - 1950 + IMGSIZE,HERO.BULLET[i].BULLET_IMAGE,TRUE);
 				break;
 			}
-			if (){
+			if (HERO.BULLET[i].living == TRUE && HERO.BULLET[i].SBP - 800 > HERO.BULLET[i].y){
 				HERO.BULLET[i].living = FALSE;
 			}
 			if(HERO.BULLET[i].living == TRUE){

--- a/space_shooting/gamemain.cpp
+++ b/space_shooting/gamemain.cpp
@@ -53,12 +53,12 @@ void gamemain(){
 	/*
 
 	*/
-
-	SET_PLAYER_BULLET();
+	int key = GetJoypadInputState(DX_INPUT_KEY_PAD1);
+	if (key & PAD_INPUT_A){
+		SET_PLAYER_BULLET();
+	}
 	DrawBullet(P);
 
-	
-	int key = GetJoypadInputState(DX_INPUT_KEY_PAD1);
 	if (key & PAD_INPUT_2){
 		if (HERO.type == beam){
 			HERO.type = red;
@@ -75,7 +75,7 @@ void gamemain(){
 	
 
 	clsDx();
-	printfDx("Y軸:%f\nX軸:%f\nスクロール量:%f\n時間:%d\nスクロール補正値:%d", HERO.y, HERO.x,scrolly, GetNowCount() / 1000 - timer / 1000,HERO.SC_Hosei);
+	printfDx("Y軸:%f\nX軸:%f\nスクロール量:%f\n時間:%d\nスクロール補正値:%d\n弾数:%d\n", HERO.y, HERO.x,scrolly, GetNowCount() - timer,HERO.SC_Hosei,HERO.soeji);
 }
 
 void DrawMap(){

--- a/space_shooting/gamemain.cpp
+++ b/space_shooting/gamemain.cpp
@@ -75,14 +75,14 @@ void gamemain(){
 	
 
 	clsDx();
-	//printfDx("Y軸:%f\nX軸:%f\nスクロール量:%f\n時間:%d\nスクロール補正値:%d", HERO.y, HERO.x,scrolly, GetNowCount() / 1000 - timer,HERO.SC_Hosei);
+	printfDx("Y軸:%f\nX軸:%f\nスクロール量:%f\n時間:%d\nスクロール補正値:%d", HERO.y, HERO.x,scrolly, GetNowCount() / 1000 - timer / 1000,HERO.SC_Hosei);
 }
 
 void DrawMap(){
 
 	DrawGraph(0, 0 - 1950 + scrolly, field, TRUE);
 
-	if (GetNowCount() / 1000 - timer > 1)IMG_FLAME_RATE++;
+	if (GetNowCount() - timer > 1000)IMG_FLAME_RATE++;
 
 	for (int y = 0; y < MAPHEIGHT; y++){
 		for (int x = 0; x < MAPWIDTH; x++){

--- a/space_shooting/loading.cpp
+++ b/space_shooting/loading.cpp
@@ -37,20 +37,20 @@ BOOL IMGhandle(){
 	if (BULLET[3] == -1)return FALSE;
 
 	/*敵機の画像読み込み（雑魚）*/
-	for (int i = 0 , soeji = 1; i < 13; i++,soeji++){
-		
-		char red[50], blue[50], green[50];
-		sprintf_s(red, "media\\赤\\%d.プレ―ン(赤).png", soeji);
-		sprintf_s(blue, "media\\青\\%d.プレ―ン(青).png", soeji);
-		sprintf_s(green, "media\\緑\\%d.プレ―ン(緑).png", soeji);
+	//for (int i = 0 , soeji = 1; i < 13; i++,soeji++){
+	//	
+	//	char red[50], blue[50], green[50];
+	//	sprintf_s(red, "media\\赤\\%d.プレ―ン(赤).png", soeji);
+	//	sprintf_s(blue, "media\\青\\%d.プレ―ン(青).png", soeji);
+	//	sprintf_s(green, "media\\緑\\%d.プレ―ン(緑).png", soeji);
 
-		G_IMGhandle[enemy1][i] = LoadGraph(red,soeji);
-		if (G_IMGhandle[enemy1][i] == -1)return FALSE;
-		G_IMGhandle[enemy2][i] = LoadGraph(blue,soeji);
-		if (G_IMGhandle[enemy2][i] == -1)return FALSE;
-		G_IMGhandle[enemy3][i] = LoadGraph(green,soeji);
-		if (G_IMGhandle[enemy3][i] == -1)return FALSE;
-	}
+	//	G_IMGhandle[enemy1][i] = LoadGraph(red,soeji);
+	//	if (G_IMGhandle[enemy1][i] == -1)return FALSE;
+	//	G_IMGhandle[enemy2][i] = LoadGraph(blue,soeji);
+	//	if (G_IMGhandle[enemy2][i] == -1)return FALSE;
+	//	G_IMGhandle[enemy3][i] = LoadGraph(green,soeji);
+	//	if (G_IMGhandle[enemy3][i] == -1)return FALSE;
+	//}
 
 	/*ボスの画像読み込み*/
 	STAGEBOSS.IMG1[0] = LoadGraph("media\\enemy_img\\STBF.png");

--- a/space_shooting/main.cpp
+++ b/space_shooting/main.cpp
@@ -28,7 +28,9 @@ int WINAPI WinMain(HINSTANCE h1, HINSTANCE hp, LPSTR lpc, int nC){
 	if (DxLib_Init() == -1)return -1;
 	if (IMGhandle() == -1)return -1;
 
-	timer = GetNowCount() / 1000;
+	timer = 0;
+	timer = GetNowCount();
+	LONGLONG a = GetNowHiPerformanceCount();
 
 	while (ProcessMessage() == 0 && CheckHitKey(KEY_INPUT_ESCAPE) == 0){
 		ClearDrawScreen();


### PR DESCRIPTION
弾丸不具合調整　　文責：早川

・発射の際に、前の弾丸の添え字を覚えておかねばならなかった

・発射の際に、時間は演算結果ではなくそのままの時間を入れておいたほうがよかった

・描画の際に、画面外に出た場合は弾丸情報を初期化したほうがよかった（タイマー情報が残り、次弾に影響していた）

↓

・タイマーで発射できるように、前の弾丸の添え字を覚えておくように変更

・タイマーで発射できるように、弾丸の time はそのまま時間を格納

・弾丸初期化用の関数を作成　_Init_PLAYER_BULLET